### PR TITLE
Bugfixes for new relic connector

### DIFF
--- a/lib/auto_connect.js
+++ b/lib/auto_connect.js
@@ -29,21 +29,31 @@ Kadira._getConnectionSettings = function() {
     app_secret: secret,
     options: options
   };
-
 };
 
+
+Kadira._validateConnectionSettings = function(settings) {
+  if (settings) {
+    return (settings.app_id && settings.app_secret) ||
+           (settings.options && settings.options.newRelicId);
+  }
+
+  return false;
+};
 
 Kadira._connectWithEnv = function() {
   if (Kadira._getConnectionSettings &&
       Kadira._getConnectionSettings instanceof Function) {
     var settings = Kadira._getConnectionSettings();
-    Kadira.connect(settings.app_id, settings.app_secret, settings.options);
+    if (Kadira._validateConnectionSettings(settings) ) {
+      Kadira.connect(settings.app_id, settings.app_secret, settings.options);
 
-    Kadira.connect = function() {
-      throw new Error('Meteor APM already connected');
-    };
+      Kadira.connect = function() {
+        throw new Error('Meteor APM already connected');
+      };
 
-    return;
+      return;
+    }
   }
 
   if(process.env.APM_APP_ID && process.env.APM_APP_SECRET && process.env.APM_OPTIONS_ENDPOINT) {

--- a/lib/common/send.js
+++ b/lib/common/send.js
@@ -1,10 +1,10 @@
 Kadira.send = function (payload, path, callback) {
-  if(!Kadira.connected)  {
-    if (Kadira.options.newRelicId) {
-      // Only NewRelic reporting enabled, so this is a NOOP.
-      return;
-    }
+  if (!Kadira.options.appId || !Kadira.options.appSecret) {
+    // console.log("Kadira send disabled - no valid config");
+    return;
+  }
 
+  if(!Kadira.connected)  {
     throw new Error("You need to connect with Kadira first, before sending messages!");
   }
 


### PR DESCRIPTION
Bug fixes for the NewRelic connector: 
*   Add some validation for the config settings. Otherwise it always tries to connect and gives
    errors.
*   Disable kadira send if the config is not valid.

@lnader  PTAL - this is a defensive fix - I tested that it works with and without newrelic config - plus  reports the metrics to new relic. But I can't reproduce the original error as I can't login into my
unity env to test this.

My password's expired or something with the accounts package is off and I get: 
```
Exception while invoking method 'login' TypeError: Cannot read property 'deactivated' of undefined
I20180111-22:59:00.364(-8)?     at server/config/accounts.coffee:60:52
I20180111-22:59:00.364(-8)?     at runAndHandleExceptions (packages/callback-hook.js:152:24)
I20180111-22:59:00.365(-8)?     at packages/callback-hook.js:159:12
I20180111-22:59:00.365(-8)?     at packages/accounts-base/accounts_server.js:142:13
I20180111-22:59:00.366(-8)?     at [object Object]._.extend.each (packages/callback-hook.js:128:15)
I20180111-22:59:00.366(-8)?     at AccountsServer.Ap._validateLogin (packages/accounts-base/accounts_server.js:139:27)
I20180111-22:59:00.367(-8)?     at AccountsServer.Ap._attemptLogin (packages/accounts-base/accounts_server.js:345:8)
I20180111-22:59:00.367(-8)?     at [object Object].methods.login (packages/accounts-base/accounts_server.js:533:21)
```
Any clues on how to fix that?  Thanks.