### PR TITLE
Fix to work with new Buffer API

### DIFF
--- a/lib/docsize_cache.js
+++ b/lib/docsize_cache.js
@@ -16,7 +16,10 @@ DocSzCache.prototype.setPcpu = function (pcpu) {
 DocSzCache.prototype.getSize = function (coll, query, opts, data) {
   // If the dataset is null or empty we can't calculate the size
   // Do not process this data and return 0 as the document size.
-  if (!(data && (data.length || (data.size && data.size())))) {
+  // We need to check that data.length is a number or data.size is a function
+  // Otherwise e.g. data==={length: "xyz"} will be interpreted as an array and break the rest of the code)
+  // But maybe a more explicit test like (Array.isArray(data) || Buffer.isBuffer(data)) is safer?
+  if (!(data && ((data.length && (typeof data.length === "number")) || (data.size && (typeof data.size === 'function') && data.size())))) {
     return 0;
   }
 
@@ -38,6 +41,12 @@ DocSzCache.prototype.getSize = function (coll, query, opts, data) {
       })
     } else {
       doc = data[0];
+    }
+    //do we need to add another case to handle the possiblity that data is an Object?
+
+    if (!doc) {
+      //if doc is undefined we don't want to pass it to Buffer.byteLength
+      return 0;
     }
     var size = Buffer.byteLength(jsonStringify(doc), 'utf8');
     item.addData(size);


### PR DESCRIPTION
  A change in the Buffer API revealed an issue with DocSzCache.getSize.
  This code appears to be attempting a type check based on fields
  present in the supplied argument, but can mistakenly identify
  objects like `{size: 1}` or `{length: 1}` as Arrays or Buffers. As a
  result an undefined value was sometimes supplied to
  `Buffer.byteLength`.

  This is a basic patch that just improves the existing logic, and adds
  an extra check to avoid passing undefined to Buffer.byteLength. More explicit
  checks (`Array.isArray(data)`, `Buffer.isBuffer(data)`) could be used instead.